### PR TITLE
Easier version restriction on httparty dependency

### DIFF
--- a/cloudability.gemspec
+++ b/cloudability.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
-  gem.add_dependency('httparty', "~> 0.9.0")
+  gem.add_dependency('httparty', ">= 0.9.0")
   gem.add_dependency('hashie')
 
   gem.add_development_dependency('rspec')


### PR DESCRIPTION
The current version restriction on httparty makes it difficult to include this gem in projects already using httparty. I revved the version httparty to the latest, and it appears all gem functionality is still intact. Tests all pass using the latest version of httparty.

If you accept this PR, it would be super helpful to have a new version of the gem uploaded to Rubygems.

Cheers!
